### PR TITLE
Changing the DEFAULT_BATCH_SIZE to 2000

### DIFF
--- a/lib/rforce/binding.rb
+++ b/lib/rforce/binding.rb
@@ -11,7 +11,9 @@ module RForce
   class Binding
     include RForce
 
-    DEFAULT_BATCH_SIZE = 10
+    # Increase the maximum fetch size to 2000, as allowed by Salesforce
+    # Added by Raymond Gao
+    DEFAULT_BATCH_SIZE = 2000
     attr_accessor :batch_size, :url, :assignment_rule_id, :use_default_rule, :update_mru, :client_id, :trigger_user_email,
       :trigger_other_email, :trigger_auto_response_email
 


### PR DESCRIPTION
Hi Undees,

I am Raymond Gao. Thank you for your excellent work on RForce. I have a small favor to ask. I have updated your GEM and changed the DEFAULT_BATCH_SIZE from 10 to 2000  on binding.rb file. Right now, even though you set it to 10, the platform minimum is 200. So, it needs update. Could you please make a new GEM for this? e.g 0.4.2

Thank you very much,

-Ray
