### PR TITLE
Allow for no-arg API calls without passing an empty array

### DIFF
--- a/lib/rforce/binding.rb
+++ b/lib/rforce/binding.rb
@@ -248,11 +248,11 @@ module RForce
 
     # Turns method calls on this object into remote SOAP calls.
     def method_missing(method, *args)
-      unless args.size == 1 && [Hash, Array].include?(args[0].class)
-        raise 'Expected 1 Hash or Array argument'
+      unless args.empty? || (args.size == 1 && [Hash, Array].include?(args[0].class))
+        raise 'Expected at most 1 Hash or Array argument'
       end
 
-      call_remote method, args[0]
+      call_remote method, args[0] || []
     end
   end
 end


### PR DESCRIPTION
RForce currently requires calling no-argument API calls with an empty array or hash as the parameter to the API call. For example, to make a call to [describeTabs](http://www.salesforce.com/us/developer/docs/api/Content/sforce_api_calls_describetabs.htm), the following code must be used:

```
binding.describeTabs [] # or binding.describeTabs {}
```

My patch will allow users of RForce to make such API calls as follows:

```
binding.describeTabs
```

I believe this is more intuitive for users that aren't familiar with the requirement to pass an empty array for no-arg SOAP calls (guilty as charged. :)

This will affect the following API calls:
- logout
- describeGlobal
- describeSoftphoneLayout
- describeTabs
- getServerTimestamp
- getUserInfo

Thanks for the great gem, and keep up the great work!
