### PR TITLE
Invalid XML in RForce::Binding::Envelope

### DIFF
--- a/lib/rforce/binding.rb
+++ b/lib/rforce/binding.rb
@@ -24,7 +24,7 @@ module RForce
 <soap:Envelope xmlns:xsd="http://www.w3.org/2001/XMLSchema"
     xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xmlns:partner="urn:partner.soap.sforce.com">
+    xmlns:partner="urn:partner.soap.sforce.com"
     xmlns:spartner="urn:sobject.partner.soap.sforce.com">
   <soap:Header>
     <partner:SessionHeader soap:mustUnderstand='1'>


### PR DESCRIPTION
While debugging a recent problem with the Web Services API, I located this stray `>` in the SOAP envelope template.
