### PR TITLE
Fix malformed request bug with retried requests 

### DIFF
--- a/lib/rforce/binding.rb
+++ b/lib/rforce/binding.rb
@@ -157,12 +157,12 @@ module RForce
       expand(@builder, {method => args}, urn)
 
       extra_headers = ""
-      
+
       # QueryOptions is not valid when making an Apex Webservice SOAP call
       if !block_given?
         extra_headers << (QueryOptions % @batch_size)
       end
-      
+
       extra_headers << (AssignmentRuleHeaderUsingRuleId % assignment_rule_id) if assignment_rule_id
       extra_headers << AssignmentRuleHeaderUsingDefaultRule if use_default_rule
       extra_headers << MruHeader if update_mru
@@ -211,7 +211,7 @@ module RForce
         login(@user, @password)
 
         # repackage and rencode request with the new session id
-        request = (Envelope % [@session_id, @batch_size, extra_headers, expanded])
+        request = (Envelope % [@session_id, extra_headers, expanded])
         request = encode(request)
 
         # Send the request to the server and read the response.


### PR DESCRIPTION
Scenario:
1. request is made via Binding#call_remote
2. session is invalid, so we login to establish a new session
3. new request is made and sent

There was a bug in step three where the request was incorrectly
recreated.  A previous fix changed the initial request construction
but missed this.
